### PR TITLE
[Update] LiveKitUniFFI (0.1.8)

### DIFF
--- a/Specs/LiveKitUniFFI/0.1.8/LiveKitUniFFI.podspec
+++ b/Specs/LiveKitUniFFI/0.1.8/LiveKitUniFFI.podspec
@@ -1,0 +1,31 @@
+# Generated from Rust template
+Pod::Spec.new do |spec|
+  spec.name = "LiveKitUniFFI"
+  spec.version = "0.1.8"
+  spec.summary = "LiveKit UniFFI bindings"
+  spec.description = <<-DESC
+    LiveKit UniFFI XCFramework with Swift bindings
+  DESC
+
+  spec.homepage = "https://github.com/livekit/livekit-uniffi-xcframework"
+  spec.author = "LiveKit"
+
+  spec.ios.deployment_target = "13.0"
+  spec.osx.deployment_target = "10.15"
+
+  spec.source = {
+    :git => "https://github.com/livekit/livekit-uniffi-xcframework.git",
+    :tag => spec.version.to_s
+  }
+
+  spec.prepare_command = <<-CMD
+    FRAMEWORK_URL="https://github.com/livekit/livekit-uniffi-xcframework/releases/download/#{spec.version}/RustLiveKitUniFFI.xcframework.zip"
+    curl -L -o RustLiveKitUniFFI.xcframework.zip "$FRAMEWORK_URL"
+    unzip -q RustLiveKitUniFFI.xcframework.zip
+    rm RustLiveKitUniFFI.xcframework.zip
+  CMD
+
+  spec.module_name = "LiveKitUniFFI"
+  spec.source_files = "Sources/LiveKitUniFFI/**/*.swift"
+  spec.vendored_frameworks = "RustLiveKitUniFFI.xcframework"
+end


### PR DESCRIPTION
Podspec copied verbatim from [livekit-uniffi-xcframework 0.1.8](https://github.com/livekit/livekit-uniffi-xcframework/releases/tag/0.1.8), same as previous versions. Unblocks the CocoaPods Lint job on livekit/client-sdk-swift#975, which resolves `LiveKitUniFFI = 0.1.8` from this source.